### PR TITLE
Specify locale in month_names of get_met_gdas1.

### DIFF
--- a/R/get_met_gdas1.R
+++ b/R/get_met_gdas1.R
@@ -42,7 +42,7 @@ get_met_gdas1 <- function(days,
   
   month_names <-
     met_months %>%
-    lubridate::month(label = TRUE, abbr = TRUE) %>%
+    lubridate::month(label = TRUE, abbr = TRUE, locale = "en_US.UTF-8") %>%
     as.character() %>%
     tolower()
   


### PR DESCRIPTION
Default to lubridate::month determines month names based on system locale, can cause an error for non-US users where non-English month names are (#42).