### PR TITLE
Solves bug and allows to keep temporary files in the working directory

### DIFF
--- a/R/add_trajectory_params.R
+++ b/R/add_trajectory_params.R
@@ -101,6 +101,7 @@ add_dispersion_params <- function(model,
                                   exec_dir = NULL,
                                   met_dir = NULL,
                                   binary_path = NULL,
+                                  binary_name = NULL,
                                   clean_up = TRUE) {
   
   if (!is.null(start_time)) {
@@ -137,6 +138,10 @@ add_dispersion_params <- function(model,
   
   if (!is.null(binary_path)) {
     model$binary_path <- binary_path
+  }
+  
+  if (!is.null(binary_name)) {
+    model$binary_name <- binary_name
   }
   
   if (!is.null(clean_up)) {

--- a/R/add_trajectory_params.R
+++ b/R/add_trajectory_params.R
@@ -24,6 +24,7 @@ add_trajectory_params <- function(model,
                                   binary_path = NULL,
                                   met_dir = NULL,
                                   exec_dir = NULL,
+                                  softrun = FALSE,
                                   clean_up = TRUE) {
   
   if (!is.null(lat)) {
@@ -82,6 +83,10 @@ add_trajectory_params <- function(model,
     model$binary_path <- binary_path
   }
   
+  if (!is.null(softrun)) {
+    model$softrun <- softrun
+  }
+  
   if (!is.null(clean_up)) {
     model$clean_up <- clean_up
   }
@@ -102,6 +107,7 @@ add_dispersion_params <- function(model,
                                   met_dir = NULL,
                                   binary_path = NULL,
                                   binary_name = NULL,
+                                  softrun = FALSE,
                                   clean_up = TRUE) {
   
   if (!is.null(start_time)) {
@@ -140,8 +146,8 @@ add_dispersion_params <- function(model,
     model$binary_path <- binary_path
   }
   
-  if (!is.null(binary_name)) {
-    model$binary_name <- binary_name
+  if (!is.null(softrun)) {
+    model$softrun <- softrun
   }
   
   if (!is.null(clean_up)) {

--- a/R/add_trajectory_params.R
+++ b/R/add_trajectory_params.R
@@ -82,6 +82,10 @@ add_trajectory_params <- function(model,
     model$binary_path <- binary_path
   }
   
+  if (!is.null(clean_up)) {
+    model$clean_up <- clean_up
+  }
+  
   model
 }
 
@@ -96,7 +100,8 @@ add_dispersion_params <- function(model,
                                   model_height = NULL,
                                   exec_dir = NULL,
                                   met_dir = NULL,
-                                  binary_path = NULL) {
+                                  binary_path = NULL,
+                                  clean_up = TRUE) {
   
   if (!is.null(start_time)) {
     model$start_time <- start_time
@@ -132,6 +137,10 @@ add_dispersion_params <- function(model,
   
   if (!is.null(binary_path)) {
     model$binary_path <- binary_path
+  }
+  
+  if (!is.null(clean_up)) {
+    model$clean_up <- clean_up
   }
   
   model

--- a/R/hysplit_dispersion.R
+++ b/R/hysplit_dispersion.R
@@ -35,6 +35,7 @@ hysplit_dispersion <- function(lat = 49.263,
                                binary_name = NULL,
                                exec_dir = NULL,
                                met_dir = NULL,
+                               softrun = NULL,
                                clean_up = TRUE) {
   
   # If the execution dir isn't specified, use the working directory
@@ -155,6 +156,7 @@ hysplit_dispersion <- function(lat = 49.263,
     exec_dir = exec_dir
   )
   
+  
   # The CONTROL file is now complete and in the
   # working directory, so, execute the model run
   sys_cmd <- 
@@ -168,7 +170,9 @@ hysplit_dispersion <- function(lat = 49.263,
       ")"
     )
   
-  execute_on_system(sys_cmd, system_type = system_type)
+  if (isFALSE(softrun)) {
+    execute_on_system(sys_cmd, system_type = system_type)
+  }
   
   # Extract the particle positions at every hour
   sys_cmd <- 
@@ -182,8 +186,11 @@ hysplit_dispersion <- function(lat = 49.263,
       ")"
     )
   
-  execute_on_system(sys_cmd, system_type = system_type)
+  if (isFALSE(softrun)) {
+    execute_on_system(sys_cmd, system_type = system_type)
+  }
   
+  if (isFALSE(softrun)) {
   dispersion_file_list <-
     list.files(
       path = exec_dir,
@@ -219,6 +226,7 @@ hysplit_dispersion <- function(lat = 49.263,
     
     dispersion_tbl <-
       dplyr::bind_rows(dispersion_tbl, disp_tbl)
+    }
   }
   
   if (clean_up) {

--- a/R/hysplit_dispersion.R
+++ b/R/hysplit_dispersion.R
@@ -4,6 +4,7 @@
 #' runs using specified meteorological datasets.
 #' 
 #' @inheritParams hysplit_trajectory
+#' @param binary_name An optional file name for the hysplit binary code. Defaults to "hycs_std", but could be "hycm_std", for example.
 #' @param start_day the day that the model will initialize and run. This should
 #'   take the form of a single-length vector for a day (`"YYYY-MM-DD"`).
 #' @param start_hour a single daily hour as an integer hour (from `0` to `23`).
@@ -31,6 +32,7 @@ hysplit_dispersion <- function(lat = 49.263,
                                species,
                                disp_name = NULL,
                                binary_path = NULL, 
+                               binary_name = NULL,
                                exec_dir = NULL,
                                met_dir = NULL,
                                clean_up = TRUE) {
@@ -41,11 +43,13 @@ hysplit_dispersion <- function(lat = 49.263,
   # If the meteorology dir isn't specified, use the working directory
   if (is.null(met_dir)) met_dir <- getwd()
   
-  # Set the path for the `hycs_std` binary file
+  # Set the path for the binary file. Defaults to "hycs_std"
+  if (is.null(binary_name)) binary_name <- "hycs_std"
+  
   hycs_std_binary_path <- 
     set_binary_path(
       binary_path = binary_path,
-      binary_name = "hycs_std"
+      binary_name = binary_name
     )
   
   parhplot_binary_path <-

--- a/R/hysplit_trajectory.R
+++ b/R/hysplit_trajectory.R
@@ -87,6 +87,7 @@ hysplit_trajectory <- function(lat = 49.263,
                                binary_path = NULL,
                                met_dir = NULL,
                                exec_dir = NULL,
+                               softrun = NULL, # This is not evaluated, yet
                                clean_up = TRUE) {
   
   # If the execution dir isn't specified, use the working directory

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -82,6 +82,7 @@ run_model <- function(model) {
           exec_dir = model$exec_dir,
           met_dir = model$met_dir,
           binary_path = model$binary_path,
+          binary_name = model$binary_name,
           clean_up = model$clean_up
         )
       

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -29,7 +29,8 @@ run_model <- function(model) {
         traj_name = model$traj_name,
         exec_dir = model$exec_dir,
         met_dir = model$met_dir,
-        binary_path = model$binary_path
+        binary_path = model$binary_path,
+        clean_up = model$clean_up
       )
     
     model$traj_df <- traj_df
@@ -80,7 +81,8 @@ run_model <- function(model) {
           species = species_list,
           exec_dir = model$exec_dir,
           met_dir = model$met_dir,
-          binary_path = model$binary_path
+          binary_path = model$binary_path,
+          clean_up = model$clean_up
         )
       
       model$disp_df <- disp_df

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -30,6 +30,7 @@ run_model <- function(model) {
         exec_dir = model$exec_dir,
         met_dir = model$met_dir,
         binary_path = model$binary_path,
+        softrun = model$softrun,
         clean_up = model$clean_up
       )
     
@@ -83,6 +84,7 @@ run_model <- function(model) {
           met_dir = model$met_dir,
           binary_path = model$binary_path,
           binary_name = model$binary_name,
+          softrun = model$softrun,
           clean_up = model$clean_up
         )
       

--- a/R/run_model.R
+++ b/R/run_model.R
@@ -48,8 +48,8 @@ run_model <- function(model) {
       # Get time window for observations
       start_day <- model$start_time %>% lubridate::floor_date()
       start_hour <- model$start_time %>% lubridate::hour() 
-      duration <- as.numeric(model$end_time - model$start_time)
-      
+      duration <- as.numeric(difftime(model$end_time, model$start_time, units = "hours"))
+    
       # Get ith source parameters
       lat <- model$sources[i, ][["lat"]]
       lon <- model$sources[i, ][["lon"]]

--- a/R/utils.R
+++ b/R/utils.R
@@ -179,10 +179,12 @@ execute_on_system <- function(sys_cmd, system_type) {
 set_binary_path <- function(binary_path,
                             binary_name) {
 
-  # binary names should be either:
+  # By default, binary names should be either:
   #  - hyts_std (trajectory models)
   #  - hycs_std (dispersion models)
 
+  # If a user uses another binary name, the path to it should also be specified
+  
   if (is.null(binary_path)) {
 
     system_os <- get_os()
@@ -210,6 +212,8 @@ set_binary_path <- function(binary_path,
           package = "splitr"
         )
     }
+  } else {
+    binary_path <- paste0(binary_path, binary_name)
   }
 
   binary_path


### PR DESCRIPTION
By default `SplitR` removes any temporary files in the working directory. 

Although there exists a parameter `clean_up` in the function `add_trajectory_params()`, it has not passed through to the model parameters and has not been considered during `run_model()`. Furthermore, this parameter did not exists for the function `add_dispersion_params()`.

This PR resolves this bug and allows users to keep any temporary files in the working directory.