### PR TITLE
[defunct] bugfixes incl. issue #57

### DIFF
--- a/R/get_met_gdas1.R
+++ b/R/get_met_gdas1.R
@@ -40,11 +40,21 @@ get_met_gdas1 <- function(days,
     seq(min_date, max_date, by = "1 day") %>% 
     lubridate::day()
   
-  month_names <- 
-    seq(min_date, max_date, by = "1 day") %>%
-    lubridate::month(label = TRUE, abbr = TRUE, locale = "en_US.UTF-8")  %>%
-    as.character() %>%
-    tolower()
+  # "en_US.UTF-8" is not a valid locale for windows. 
+  os_for_locale <- get_os()
+  if(os_for_locale == "win"){
+    month_names <- 
+      seq(min_date, max_date, by = "1 day") %>%
+      lubridate::month(label = TRUE, abbr = TRUE, locale = Sys.getlocale("LC_TIME"))  %>%
+      as.character() %>%
+      tolower()
+  } else {
+    month_names <- 
+      seq(min_date, max_date, by = "1 day") %>%
+      lubridate::month(label = TRUE, abbr = TRUE, locale = "en_US.UTF-8")  %>%
+      as.character() %>%
+      tolower()
+  }
   
   met_years <- 
     seq(min_date, max_date, by = "1 day") %>%

--- a/R/hysplit_trajectory.R
+++ b/R/hysplit_trajectory.R
@@ -218,7 +218,7 @@ hysplit_trajectory <- function(lat = 49.263,
       # Make nested loop with daily beginning hours
       for (j in daily_hours) {
         
-        start_hour_GMT <- j
+        start_hour_GMT <- daily_hours[j]
         
         if (start_year_GMT > 40) {
           full_year_GMT <- paste0("19", start_year_GMT)


### PR DESCRIPTION
Two fixes:
1) start time-hours  not indexed properly in hysplit_trajectory control file write loop, leading to weird behaviour when running trajectories.
2) locale handling in get_met_gdas1 was throwing up errors for some windows users. Fix integrated as per issue [#57](https://github.com/rich-iannone/splitr/issues/57) 